### PR TITLE
The source :rubygems is deprecated because HTTP requests are insecure. c...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     paypal-recurring (1.1.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.3)
       i18n (~> 0.6)


### PR DESCRIPTION
change :rubygems to 'https://rubygems.org'
