### PR TITLE
Ipn notifications

### DIFF
--- a/lib/paypal/recurring/notification.rb
+++ b/lib/paypal/recurring/notification.rb
@@ -50,6 +50,10 @@ module PayPal
         type == "recurring_payment_suspended"
       end
 
+      def recurring_payment_profile_cancel?
+        type == "recurring_payment_profile_cancel"
+      end
+
       def request
         @request ||= PayPal::Recurring::Request.new.tap do |request|
           request.uri = URI.parse("#{PayPal::Recurring.site_endpoint}?cmd=_notify-validate")

--- a/lib/paypal/recurring/notification.rb
+++ b/lib/paypal/recurring/notification.rb
@@ -46,6 +46,10 @@ module PayPal
         type == "recurring_payment_profile_created"
       end
 
+      def recurring_payment_suspended?
+        type == "recurring_payment_suspended"
+      end
+
       def request
         @request ||= PayPal::Recurring::Request.new.tap do |request|
           request.uri = URI.parse("#{PayPal::Recurring.site_endpoint}?cmd=_notify-validate")

--- a/lib/paypal/recurring/notification.rb
+++ b/lib/paypal/recurring/notification.rb
@@ -65,7 +65,15 @@ module PayPal
       end
 
       def valid?
-        completed? && verified? && email == PayPal::Recurring.email && seller_id == PayPal::Recurring.seller_id
+        if payment_received?
+          completed? && verified? && email == PayPal::Recurring.email && seller_id == PayPal::Recurring.seller_id
+        else
+          verified? && email == PayPal::Recurring.email
+        end
+      end
+
+      def payment_received?
+        express_checkout? || recurring_payment?
       end
 
       def completed?

--- a/spec/paypal/notification_spec.rb
+++ b/spec/paypal/notification_spec.rb
@@ -16,6 +16,16 @@ describe PayPal::Recurring::Notification do
     subject.should be_recurring_payment_profile
   end
 
+  it "detects recurring payment suspended" do
+    subject.params[:txn_type] = "recurring_payment_suspended"
+    subject.should be_recurring_payment_suspended
+  end
+
+  it "detects recurring payment profile cancel" do
+    subject.params[:txn_type] = "recurring_payment_profile_cancel"
+    subject.should be_recurring_payment_profile_cancel
+  end
+
   it "normalizes payment date" do
     subject.params[:payment_date] = "20:37:06 Jul 04, 2011 PDT" # PDT = -0700
     subject.paid_at.strftime("%Y-%m-%d %H:%M:%S").should == "2011-07-05 03:37:06"


### PR DESCRIPTION
I have added two new methods to verify the transaction type of two Paypal IPN notifications that are not currently managed: `recurring_payment_suspended?` and `recurring_payment_profile_cancel?`.

I have also updated the `valid?` method because notifications related to transaction payments provide more information than the rest of notifications (example: `seller_id` parameter), and `valid?` was not prepared to handle this specific cases.
