### PR TITLE
remove duplicate hash key

### DIFF
--- a/lib/paypal/recurring/response/details.rb
+++ b/lib/paypal/recurring/response/details.rb
@@ -5,7 +5,6 @@ module PayPal
         mapping(
           :status       => :CHECKOUTSTATUS,
           :email        => :EMAIL,
-          :email        => :EMAIL,
           :payer_id     => :PAYERID,
           :payer_status => :PAYERSTATUS,
           :first_name   => :FIRSTNAME,


### PR DESCRIPTION
triggers warning in Ruby 2.3.0 (and possibly earlier)
